### PR TITLE
expose 'counters' and 'job_id' to MapReducePipeline output

### DIFF
--- a/python/src/mapreduce/mapreduce_pipeline.py
+++ b/python/src/mapreduce/mapreduce_pipeline.py
@@ -96,6 +96,9 @@ class MapPipeline(pipeline_base._OutputSlotsMixin,
 
 class ReducePipeline(pipeline_base._OutputSlotsMixin,
                      pipeline_base.PipelineBase):
+
+  output_names = mapper_pipeline.MapperPipeline.output_names
+
   """Runs the reduce stage of MapReduce.
 
   Merge-reads input files and runs reducer function on them.
@@ -187,6 +190,8 @@ class MapreducePipeline(pipeline_base._OutputSlotsMixin,
       was outputting files. An empty list otherwise.
   """
 
+  output_names = mapper_pipeline.MapperPipeline.output_names
+
   def run(self,
           job_name,
           mapper_spec,
@@ -234,6 +239,8 @@ class MapreducePipeline(pipeline_base._OutputSlotsMixin,
 
     yield _ReturnPipeline(map_pipeline.result_status,
                           reducer_pipeline.result_status,
+                          reducer_pipeline.counters,
+                          reducer_pipeline.job_id,
                           reducer_pipeline)
 
 
@@ -244,11 +251,13 @@ class _ReturnPipeline(pipeline_base._OutputSlotsMixin,
   Fills outputs for MapreducePipeline. See MapreducePipeline.
   """
 
-  output_names = ["result_status"]
+  output_names = mapper_pipeline.MapperPipeline.output_names
 
   def run(self,
           map_result_status,
           reduce_result_status,
+          reduce_counters,
+          job_id,
           reduce_outputs):
 
     if (map_result_status == model.MapreduceState.RESULT_ABORTED or
@@ -261,6 +270,8 @@ class _ReturnPipeline(pipeline_base._OutputSlotsMixin,
       result_status = model.MapreduceState.RESULT_SUCCESS
 
     self.fill(self.outputs.result_status, result_status)
+    self.fill(self.outputs.counters, reduce_counters)
+    self.fill(self.outputs.job_id, job_id)
     if result_status == model.MapreduceState.RESULT_SUCCESS:
       yield pipeline_common.Return(reduce_outputs)
     else:


### PR DESCRIPTION
MapperPipeline returns named outputs:
- `counters`
- `job_id`

To expose these from the `ReducePipeline.MapperPipeline` to the
MapReduce pipeline, the outputs must be named and passed through
`MapReducePipeline`
