### PR TITLE
Fix MANIFEST.in #12

### DIFF
--- a/python/src/MANIFEST.in
+++ b/python/src/MANIFEST.in
@@ -1,3 +1,4 @@
 include distribute_setup.py
+include mapreduce/include.yaml
 recursive-include mapreduce/static *.html *.css *.js
-recursive-include mapreduce/lib/pipeline *.html *.css *.js *.gif
+recursive-include mapreduce/third_party/pipeline/ui *.html *.css *.js *.gif


### PR DESCRIPTION
The sdist archive built by setup.py is missing `include.yaml` and the 
pipeline UI.

Updates MANIFEST.in to include them.
