### PR TITLE
Use json instead of simplejson whenever possible #36

### DIFF
--- a/python/src/mapreduce/base_handler.py
+++ b/python/src/mapreduce/base_handler.py
@@ -24,7 +24,10 @@
 import httplib
 import logging
 
-import simplejson
+try:
+  import json
+except ImportError:
+  import simplejson as json
 
 try:
   from mapreduce import pipeline_base
@@ -224,7 +227,7 @@ class JsonHandler(webapp.RequestHandler):
 
     self.response.headers["Content-Type"] = "text/javascript"
     try:
-      output = simplejson.dumps(self.json_response, cls=json_util.JsonEncoder)
+      output = json.dumps(self.json_response, cls=json_util.JsonEncoder)
     # pylint: disable=broad-except
     except Exception, e:
       logging.exception("Could not serialize to JSON")

--- a/python/src/mapreduce/handlers.py
+++ b/python/src/mapreduce/handlers.py
@@ -29,7 +29,11 @@ import random
 import sys
 import time
 import traceback
-import simplejson
+
+try:
+  import json
+except ImportError:
+  import simplejson as json
 
 from google.appengine.ext import ndb
 
@@ -1436,8 +1440,8 @@ class KickOffJobHandler(base_handler.TaskQueueHandler):
     if serialized_input_readers is None:
       readers = input_reader_class.split_input(split_param)
     else:
-      readers = [input_reader_class.from_json_str(json) for json in
-                 simplejson.loads(serialized_input_readers.payload)]
+      readers = [input_reader_class.from_json_str(_json) for _json in
+                 json.loads(serialized_input_readers.payload)]
 
     if not readers:
       return None, None
@@ -1452,7 +1456,7 @@ class KickOffJobHandler(base_handler.TaskQueueHandler):
       serialized_input_readers = model._HugeTaskPayload(
           key_name=serialized_input_readers_key, parent=state)
       readers_json_str = [i.to_json_str() for i in readers]
-      serialized_input_readers.payload = simplejson.dumps(readers_json_str)
+      serialized_input_readers.payload = json.dumps(readers_json_str)
     return readers, serialized_input_readers
 
   def _setup_output_writer(self, state):

--- a/python/src/mapreduce/model.py
+++ b/python/src/mapreduce/model.py
@@ -42,7 +42,11 @@ import urllib
 import zlib
 
 from graphy.backends import google_chart_api
-import simplejson
+
+try:
+  import json
+except ImportError:
+  import simplejson as json
 
 from google.appengine.api import memcache
 from google.appengine.api import taskqueue
@@ -788,11 +792,11 @@ class TransientShardState(object):
     """Create new TransientShardState from webapp request."""
     mapreduce_spec = MapreduceSpec.from_json_str(request.get("mapreduce_spec"))
     mapper_spec = mapreduce_spec.mapper
-    input_reader_spec_dict = simplejson.loads(request.get("input_reader_state"),
-                                              cls=json_util.JsonDecoder)
+    input_reader_spec_dict = json.loads(request.get("input_reader_state"),
+                                        cls=json_util.JsonDecoder)
     input_reader = mapper_spec.input_reader_class().from_json(
         input_reader_spec_dict)
-    initial_input_reader_spec_dict = simplejson.loads(
+    initial_input_reader_spec_dict = json.loads(
         request.get("initial_input_reader_state"), cls=json_util.JsonDecoder)
     initial_input_reader = mapper_spec.input_reader_class().from_json(
         initial_input_reader_spec_dict)
@@ -800,8 +804,8 @@ class TransientShardState(object):
     output_writer = None
     if mapper_spec.output_writer_class():
       output_writer = mapper_spec.output_writer_class().from_json(
-          simplejson.loads(request.get("output_writer_state", "{}"),
-                           cls=json_util.JsonDecoder))
+          json.loads(request.get("output_writer_state", "{}"),
+                     cls=json_util.JsonDecoder))
       assert isinstance(output_writer, mapper_spec.output_writer_class()), (
           "%s.from_json returned an instance of wrong class: %s" % (
               mapper_spec.output_writer_class(),

--- a/python/test/mapreduce/handlers_test.py
+++ b/python/test/mapreduce/handlers_test.py
@@ -40,7 +40,11 @@ import unittest
 
 import mock
 import mox
-import simplejson
+
+try:
+  import json
+except ImportError:
+  import simplejson as json
 
 from google.appengine.api import apiproxy_stub_map
 from google.appengine.api import datastore
@@ -1133,7 +1137,7 @@ class KickOffJobHandlerTest(testutil.HandlerTestBase):
     # Serialized new readers should be the same as serialized old ones.
     self.assertEqual(serialized_readers_entity.payload,
                      new_serialized_readers_entity.payload)
-    self.assertEqual(simplejson.dumps([i.to_json_str() for i in new_readers]),
+    self.assertEqual(json.dumps([i.to_json_str() for i in new_readers]),
                      serialized_readers_entity.payload)
 
   def testSaveState(self):
@@ -2845,7 +2849,7 @@ class CleanUpJobTest(testutil.HandlerTestBase):
     self.assertTrue(db.get(key))
     self.handler.request.set("mapreduce_id", self.mapreduce_id)
     self.handler.post()
-    result = simplejson.loads(self.handler.response.out.getvalue())
+    result = json.loads(self.handler.response.out.getvalue())
     self.assertEquals({"status": ("Job %s successfully cleaned up." %
                                   self.mapreduce_id) },
                       result)

--- a/python/test/mapreduce/json_util_test.py
+++ b/python/test/mapreduce/json_util_test.py
@@ -50,7 +50,7 @@ class JsonSerializationTest(unittest.TestCase):
   def testE2e(self):
     now = datetime.datetime.now()
     obj = {"a": 1, "b": [{"c": "d"}], "e": now}
-    new_obj = json_util.simplejson.loads(json_util.simplejson.dumps(
+    new_obj = json_util.json.loads(json_util.json.dumps(
         obj, cls=json_util.JsonEncoder), cls=json_util.JsonDecoder)
     self.assertEquals(obj, new_obj)
 

--- a/python/test/mapreduce/status_test.py
+++ b/python/test/mapreduce/status_test.py
@@ -18,11 +18,15 @@
 
 
 import os
-import simplejson
 import shutil
 import tempfile
 import time
 import unittest
+
+try:
+  import json
+except ImportError:
+  import simplejson as json
 
 from google.appengine.api import yaml_errors
 from google.appengine.ext import db
@@ -373,7 +377,7 @@ class ListConfigsTest(testutil.HandlerTestBase):
            u'params': {
                u'foo': u'bar',},
            }]},
-        simplejson.loads(self.handler.response.out.getvalue()))
+        json.loads(self.handler.response.out.getvalue()))
     self.assertEquals("text/javascript",
                       self.handler.response.headers["Content-Type"])
 
@@ -427,7 +431,7 @@ class ListJobsTest(testutil.HandlerTestBase):
     self.start.post()
 
     self.handler.get()
-    result = simplejson.loads(self.handler.response.out.getvalue())
+    result = json.loads(self.handler.response.out.getvalue())
     expected_args = set([
         "active",
         "active_shards",
@@ -458,7 +462,7 @@ class ListJobsTest(testutil.HandlerTestBase):
 
     self.handler.request.set("count", "1")
     self.handler.get()
-    result = simplejson.loads(self.handler.response.out.getvalue())
+    result = json.loads(self.handler.response.out.getvalue())
     self.assertEquals(1, len(result["jobs"]))
     self.assertTrue("cursor" in result)
 
@@ -466,14 +470,14 @@ class ListJobsTest(testutil.HandlerTestBase):
     self.handler.request.set("count", "1")
     self.handler.request.set("cursor", result['cursor'])
     self.handler.get()
-    result2 = simplejson.loads(self.handler.response.out.getvalue())
+    result2 = json.loads(self.handler.response.out.getvalue())
     self.assertEquals(1, len(result2["jobs"]))
     self.assertFalse("cursor" in result2)
 
   def testNoJobs(self):
     """Tests when there are no jobs."""
     self.handler.get()
-    result = simplejson.loads(self.handler.response.out.getvalue())
+    result = json.loads(self.handler.response.out.getvalue())
     self.assertEquals({'jobs': []}, result)
 
 
@@ -500,7 +504,7 @@ class GetJobDetailTest(testutil.HandlerTestBase):
     self.start.request.headers["X-Requested-With"] = "XMLHttpRequest"
 
     self.start.post()
-    result = simplejson.loads(self.start.response.out.getvalue())
+    result = json.loads(self.start.response.out.getvalue())
     self.mapreduce_id = result["mapreduce_id"]
 
     self.handler = status.GetJobDetailHandler()
@@ -525,7 +529,7 @@ class GetJobDetailTest(testutil.HandlerTestBase):
     self.KickOffMapreduce()
     self.handler.request.set("mapreduce_id", self.mapreduce_id)
     self.handler.get()
-    result = simplejson.loads(self.handler.response.out.getvalue())
+    result = json.loads(self.handler.response.out.getvalue())
 
     expected_keys = set([
         "active", "chart_url", "counters", "mapper_spec", "mapreduce_id",
@@ -544,7 +548,7 @@ class GetJobDetailTest(testutil.HandlerTestBase):
     """Tests getting the job details."""
     self.handler.request.set("mapreduce_id", self.mapreduce_id)
     self.handler.get()
-    result = simplejson.loads(self.handler.response.out.getvalue())
+    result = json.loads(self.handler.response.out.getvalue())
 
     expected_keys = set([
         "active", "chart_url", "counters", "mapper_spec", "mapreduce_id",
@@ -557,7 +561,7 @@ class GetJobDetailTest(testutil.HandlerTestBase):
     """Tests when an invalid job ID is supplied."""
     self.handler.request.set("mapreduce_id", "does not exist")
     self.handler.get()
-    result = simplejson.loads(self.handler.response.out.getvalue())
+    result = json.loads(self.handler.response.out.getvalue())
     self.assertEquals(
         {"error_message": "\"Could not find job with ID 'does not exist'\"",
          "error_class": "KeyError"},


### PR DESCRIPTION
See #36

Renamed some variables from json to _json to avoid name conflicts.