### PR TITLE
Delete the mapreduce context at the end of the handler execution.

### DIFF
--- a/python/src/mapreduce/handlers.py
+++ b/python/src/mapreduce/handlers.py
@@ -520,6 +520,7 @@ class MapperWorkerCallbackHandler(base_handler.HugeTaskHandler):
     """Handler should always call this as the last statement."""
     task_directive = self._set_state(shard_state, tstate, task_directive)
     self._save_state_and_schedule_next(shard_state, tstate, task_directive)
+    context.Context._set(None)
 
   def _process_inputs(self,
                       input_reader,


### PR DESCRIPTION
We don't want this context sticking around beyond the life of this request (into other requests on the same thread). Code that runs both in and out of mapreduces may be confused and act as part of stale mapreduces (or be confused when the context doesn't reflect an execution condition they could ever normally see, with missing variables, etc)