### PR TITLE
Enable ndb.KeyProperty filters using urlsafe strings

### DIFF
--- a/python/src/mapreduce/input_readers.py
+++ b/python/src/mapreduce/input_readers.py
@@ -677,7 +677,7 @@ class DatastoreInputReader(AbstractDatastoreInputReader):
       # Validate the value of each filter. We need to know filters have
       # valid value to carry out splits.
       try:
-        properties[prop].validate(val)
+        properties[prop]._do_validate(val)
       except db.BadValueError, e:
         raise errors.BadReaderParamsError(e)
 

--- a/python/src/mapreduce/json_util.py
+++ b/python/src/mapreduce/json_util.py
@@ -12,6 +12,7 @@ except ImportError:
 from google.appengine.api import datastore_errors
 from google.appengine.api import datastore_types
 from google.appengine.ext import db
+from google.appengine.ext import ndb
 
 
 # pylint: disable=invalid-name
@@ -94,6 +95,20 @@ _TYPE_NAME_TO_DECODER = {}
 _register_json_primitive(datetime.datetime,
                          _json_encode_datetime,
                          _json_decode_datetime)
+
+# ndb.Key
+def _JsonEncodeKey(o):
+    """Json encode an ndb.Key object."""
+    return {'key_string': o.urlsafe()}
+
+def _JsonDecodeKey(d):
+    """Json decode a ndb.Key object."""
+    k_c = d['key_string']
+    if isinstance(k_c, (list, tuple)):
+        return ndb.Key(flat=k_c)
+    return ndb.Key(urlsafe=d['key_string'])
+
+_register_json_primitive(ndb.Key, _JsonEncodeKey, _JsonDecodeKey)
 
 
 class JsonMixin(object):


### PR DESCRIPTION
Enables `input_readers.DatastoreInputReader` to filter against `ndb.KeyProperty` (and `ndb.ComputedProperty`) by attempting to cast `urlsafe()` values to be casted to `ndb.Key` on filter validation.

Also provides an `ndb.Key` JSON decode/encoding mechanism via `_register_json_primitive`.