### PR TITLE
Update route to pipeline UI.

### DIFF
--- a/python/src/mapreduce/include.yaml
+++ b/python/src/mapreduce/include.yaml
@@ -1,6 +1,6 @@
 handlers:
 - url: /mapreduce/pipeline/images
-  static_dir: mapreduce/lib/pipeline/ui/images
+  static_dir: pipeline/ui/images
 
 - url: /mapreduce(/.*)?
   script: mapreduce.main.APP


### PR DESCRIPTION
The Pipelines API has been removed to an external library and the route in include.yaml no longer points to a valid location. This would assume that pipeline exists somewhere on your path.