### PR TITLE
Fix status_test.MapreduceYamlTest.testFindYamlFile to understand links

### DIFF
--- a/python/test/mapreduce/status_test.py
+++ b/python/test/mapreduce/status_test.py
@@ -83,7 +83,7 @@ class MapreduceYamlTest(unittest.TestCase):
     self.set_up_directory_tree(test_dict)
     os.chdir(os.path.dirname(test_mapreduce_yaml))
     yaml_loc = status.find_mapreduce_yaml(status_file=test_status)
-    self.assertEqual(test_mapreduce_yaml, yaml_loc)
+    self.assertTrue(os.path.samefile(test_mapreduce_yaml, yaml_loc))
 
   def testFindYamlFileSameTree(self):
     """Test if mapreduce.yaml can be found with the same app/library tree."""


### PR DESCRIPTION
When I ran this test, it failed as such:

```
python test/mapreduce/status_test.py
```

```
FAIL: testFindYamlFile (__main__.MapreduceYamlTest)
Test if mapreduce.yaml can be found with different app/library trees.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/mapreduce/status_test.py", line 86, in testFindYamlFile
    self.assertEqual(test_mapreduce_yaml, yaml_loc)
AssertionError: '/var/folders/n9/4yrw2x0d1tjfz616j_wj7s0c0000gn/T/tmpY6leDS/application_root/mapreduce.yaml' != '/private/var/folders/n9/4yrw2x0d1tjfz616j_wj7s0c0000gn/T/tmpY6leDS/application_root/mapreduce.yaml'
```

This should not happen because, on my system, `/var` is merely a link to `/private/var`:

```
$ ls /var
lrwxr-xr-x@ 1 root  wheel    11B Dec 12 13:45 /var -> private/var
```

So, I changed the assertion to use the smarter `os.path.samefile()` function, which understands when different paths point to the same object.

Test Plan:
`python test/mapreduce/status_test.py`