### PR TITLE
Add zipimport compatability to ResourceHandler

### DIFF
--- a/python/src/mapreduce/status.py
+++ b/python/src/mapreduce/status.py
@@ -284,12 +284,12 @@ class ResourceHandler(webapp.RequestHandler):
     real_path, content_type = self._RESOURCE_MAP[relative]
     path = os.path.join(os.path.dirname(__file__), "static", real_path)
 
-    # It's possible we're inside a zipfile (zipimport).  If so,
-    # __file__ will start with 'something.zip'.
-    (possible_zipfile, zip_path) = os.path.relpath(path).split(os.sep, 1)
-    try:
-      content = zipfile.ZipFile(possible_zipfile).read(zip_path)
-    except (IOError, OSError, zipfile.BadZipfile):
+    # It's possible we're inside a zipfile (zipimport).  If so, path
+    # will include 'something.zip'.
+    if ('.zip' + os.sep) in path:
+      (zip_file, zip_path) = os.path.relpath(path).split('.zip' + os.sep, 1)
+      content = zipfile.ZipFile(zip_file + '.zip').read(zip_path)
+    else:
       try:
         data = pkgutil.get_data(__name__, "static/" + real_path)
       except AttributeError:  # Python < 2.6.


### PR DESCRIPTION
Appengine supports zipimport which is described here: https://cloud.google.com/appengine/articles/django10_zipimport

Some appengine users may upload the mapreduce library within a .zip file. For example, Khan Academy has a third_party.zip file which contains this library and its source code. This confuses the `ResourceHandler` when it gets a path like `/foo/bar/third_party.zip/mapreduce/python/src`. These changes fix that and have been running in production at Khan Academy for 2.5 years.

I investigated adding a test case for this scenario, but it would be difficult since the status_test.py script imports from the mapreduce module. Maybe you could do something like add a status_test_runner.py that zips the mapreduce module, performs the approprate `sys.path` manipulation, and then calls status_test.py, but this seemed like overkill for such a simple change.