### PR TITLE
Properly get kind from ndb.Model classes

### DIFF
--- a/python/src/mapreduce/input_readers.py
+++ b/python/src/mapreduce/input_readers.py
@@ -661,7 +661,7 @@ class DatastoreInputReader(AbstractDatastoreInputReader):
       if prop not in properties:
         raise errors.BadReaderParamsError(
             "Property %s is not defined for entity type %s",
-            prop, model_class.kind())
+            prop, model_class._get_kind())
 
       # Attempt to cast the value to a KeyProperty if appropriate.
       # This enables filtering against keys.


### PR DESCRIPTION
When running test cases with

```
python test/mapreduce/input_readers_test.py
```

I encountered this error:

```
ERROR: testValidate_Filters (__main__.DatastoreInputReaderNdbTest)
Tests validating filters parameter.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/mapreduce/input_readers_test.py", line 789, in testValidate_Filters
    mapper_spec)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 475, in assertRaises
    callableObj(*args, **kwargs)
  File "/Users/mattfaus/dev/webapp/third_party/appengine-mapreduce-khansrc/python/src/mapreduce/input_readers.py", line 628, in validate
    cls._validate_filters_ndb(filters, model_class)
  File "/Users/mattfaus/dev/webapp/third_party/appengine-mapreduce-khansrc/python/src/mapreduce/input_readers.py", line 681, in _validate_filters_ndb
    prop, model_class.kind())
AttributeError: type object 'NdbTestEntity' has no attribute 'kind'
```

This makes sense because the `ndb.Model` class does not provide a `kind()` function. That's only on `db.Model`. On `ndb.Model` it's called `_get_kind()`.

https://cloud.google.com/appengine/docs/python/datastore/modelclass#Model_kind
https://cloud.google.com/appengine/docs/python/ndb/modelclass

Test Plan:

```
python test/mapreduce/input_readers_test.py
```