### PR TITLE
Add color to graphs on job status page

### DIFF
--- a/python/src/mapreduce/model.py
+++ b/python/src/mapreduce/model.py
@@ -668,7 +668,6 @@ class MapreduceState(db.Model):
       # Auto-spacing does not work for large numbers of shards.
       pixels_per_shard = 700.0 / shard_count
       bar_thickness = int(pixels_per_shard * .9)
-      logging.error("thickness = %d", bar_thickness)
 
       chart.style = bar_chart.BarChartStyle(bar_thickness=bar_thickness,
         bar_gap=0.1, use_fractional_gap_spacing=True)

--- a/python/src/mapreduce/model.py
+++ b/python/src/mapreduce/model.py
@@ -41,6 +41,7 @@ import datetime
 import urllib
 import zlib
 
+from graphy import bar_chart
 from graphy.backends import google_chart_api
 
 try:
@@ -644,26 +645,37 @@ class MapreduceState(db.Model):
     chart = google_chart_api.BarChart()
 
     def filter_status(status_to_filter):
-        return [count if status == status_to_filter else 0
-                for count, status in zip(shards_processed, shards_status)]
+      return [count if status == status_to_filter else 0
+              for count, status in zip(shards_processed, shards_status)]
 
     if shards_status:
-        # Each index will have only one non-zero count, so stack them to color-
-        # code the bars by status
-        # These status values are computed in _update_state_from_shard_states,
-        # in mapreduce/handlers.py.
-        chart.stacked = True
-        chart.AddBars(filter_status("unknown"), color="404040")
-        chart.AddBars(filter_status("success"), color="00ac42")
-        chart.AddBars(filter_status("running"), color="3636a9")
-        chart.AddBars(filter_status("aborted"), color="e29e24")
-        chart.AddBars(filter_status("failed"), color="f6350f")
+      # Each index will have only one non-zero count, so stack them to color-
+      # code the bars by status
+      # These status values are computed in _update_state_from_shard_states,
+      # in mapreduce/handlers.py.
+      chart.stacked = True
+      chart.AddBars(filter_status("unknown"), color="404040")
+      chart.AddBars(filter_status("success"), color="00ac42")
+      chart.AddBars(filter_status("running"), color="3636a9")
+      chart.AddBars(filter_status("aborted"), color="e29e24")
+      chart.AddBars(filter_status("failed"), color="f6350f")
     else:
-        chart.AddBars(shards_processed)
+      chart.AddBars(shards_processed)
 
     shard_count = len(shards_processed)
 
-    if shards_processed:
+    if shard_count > 95:
+      # Auto-spacing does not work for large numbers of shards.
+      pixels_per_shard = 700.0 / shard_count
+      bar_thickness = int(pixels_per_shard * .9)
+      logging.error("thickness = %d", bar_thickness)
+
+      chart.style = bar_chart.BarChartStyle(bar_thickness=bar_thickness,
+        bar_gap=0.1, use_fractional_gap_spacing=True)
+
+    if shards_processed and shard_count <= 95:
+      # Adding labels puts us in danger of exceeding the URL length, only
+      # do it when we have a small amount of data to plot.
       # Only 16 labels on the whole chart.
       stride_length = max(1, shard_count / 16)
       chart.bottom.labels = []

--- a/python/test/mapreduce/model_test.py
+++ b/python/test/mapreduce/model_test.py
@@ -255,7 +255,7 @@ class MapreduceStateTest(unittest.TestCase):
   def testSetProcessedCounts(self):
     """Test set_processed_counts method."""
     mapreduce_state = model.MapreduceState.create_new()
-    mapreduce_state.set_processed_counts([1, 2])
+    mapreduce_state.set_processed_counts([1, 2], ['running', 'running'])
     self.assertTrue(mapreduce_state.chart_url.startswith(
         "http://chart.apis.google.com/chart?"))
     self.assertEquals(


### PR DESCRIPTION
As described in the commit messages, makes the graph pages prettier, like this:

![color-coded graph of an in-progress job](https://s3.amazonaws.com/uploads.hipchat.com/6574/48154/hU508blZbfrVtg8/upload.png)

![color-coded graph of a failed job](https://s3.amazonaws.com/uploads.hipchat.com/6574/48154/87fvNmz26ywB3uB/upload.png)

It also fixes status pages for jobs with many shards from erroring.