### PR TITLE
Improve sharding of inequality filters

### DIFF
--- a/python/src/mapreduce/handlers.py
+++ b/python/src/mapreduce/handlers.py
@@ -29,6 +29,7 @@ import random
 import sys
 import time
 import traceback
+import zlib
 
 try:
   import json
@@ -1442,7 +1443,8 @@ class KickOffJobHandler(base_handler.TaskQueueHandler):
       readers = input_reader_class.split_input(split_param)
     else:
       readers = [input_reader_class.from_json_str(_json) for _json in
-                 json.loads(serialized_input_readers.payload)]
+                 json.loads(zlib.decompress(
+                 serialized_input_readers.payload))]
 
     if not readers:
       return None, None
@@ -1457,7 +1459,8 @@ class KickOffJobHandler(base_handler.TaskQueueHandler):
       serialized_input_readers = model._HugeTaskPayload(
           key_name=serialized_input_readers_key, parent=state)
       readers_json_str = [i.to_json_str() for i in readers]
-      serialized_input_readers.payload = json.dumps(readers_json_str)
+      serialized_input_readers.payload = zlib.compress(json.dumps(
+                                                       readers_json_str))
     return readers, serialized_input_readers
 
   def _setup_output_writer(self, state):

--- a/python/src/mapreduce/input_readers.py
+++ b/python/src/mapreduce/input_readers.py
@@ -709,9 +709,9 @@ class DatastoreInputReader(AbstractDatastoreInputReader):
     # Day property and the data points tend to be clumped on certain days (say,
     # Monday and Wednesday), instead of assigning each shard a single day of
     # the week, we will split each day into "oversplit_factor" pieces, and
-    # assign each shard 7 pieces with "1 / oversplit_factor" the work, so that
-    # the data from Monday and Wednesday is more evenly spread across all
-    # shards.
+    # assign each shard "oversplit_factor" pieces with "1 / oversplit_factor"
+    # the work, so that the data from Monday and Wednesday is more evenly
+    # spread across all shards.
     oversplit_factor = query_spec.oversplit_factor
     oversplit_shard_count = oversplit_factor * shard_count
     p_range = property_range.PropertyRange(query_spec.filters,

--- a/python/src/mapreduce/model.py
+++ b/python/src/mapreduce/model.py
@@ -1182,12 +1182,14 @@ class QuerySpec(object):
   """Encapsulates everything about a query needed by DatastoreInputReader."""
 
   DEFAULT_BATCH_SIZE = 50
+  DEFAULT_OVERSPLIT_FACTOR = 1
 
   def __init__(self,
                entity_kind,
                keys_only=None,
                filters=None,
                batch_size=None,
+               oversplit_factor=None,
                model_class_path=None,
                app=None,
                ns=None):
@@ -1195,6 +1197,8 @@ class QuerySpec(object):
     self.keys_only = keys_only or False
     self.filters = filters or None
     self.batch_size = batch_size or self.DEFAULT_BATCH_SIZE
+    self.oversplit_factor = (oversplit_factor or
+                             self.DEFAULT_OVERSPLIT_FACTOR)
     self.model_class_path = model_class_path
     self.app = app
     self.ns = ns

--- a/python/src/mapreduce/model.py
+++ b/python/src/mapreduce/model.py
@@ -1208,6 +1208,7 @@ class QuerySpec(object):
             "keys_only": self.keys_only,
             "filters": self.filters,
             "batch_size": self.batch_size,
+            "oversplit_factor": self.oversplit_factor,
             "model_class_path": self.model_class_path,
             "app": self.app,
             "ns": self.ns}
@@ -1218,6 +1219,7 @@ class QuerySpec(object):
                json["keys_only"],
                json["filters"],
                json["batch_size"],
+               json["oversplit_factor"],
                json["model_class_path"],
                json["app"],
                json["ns"])


### PR DESCRIPTION
As described in the commit messages, improves sharding for jobs that filter based on property inequalities. We have seen dramatic performance improvements for mapreduce jobs that do time-based filtering due to the natural peak-and-trough of web traffic. Tony's screenshots were lost in our code review system, but they had the classic "wave pattern" to "straight line" progression.