### PR TITLE
Don't fail when speciyfing BigQueryFieldMarshaller for unsupported ty…

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/BigQueryDataMarshallerByType.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/BigQueryDataMarshallerByType.java
@@ -51,9 +51,6 @@ final class BigQueryDataMarshallerByType implements Serializable {
    * @return a nested map of field name to field value.
    */
   Map<String, Object> mapFieldNameToValue(Object toMap) {
-    if (toMap == null) {
-      return null;
-    }
     Class<?> typeOfObjectToMap = toMap.getClass();
     Map<String, Object> toRet = new HashMap<>();
     Set<Field> fieldsToMap = getFieldsToSerialize(typeOfObjectToMap);
@@ -66,6 +63,9 @@ final class BigQueryDataMarshallerByType implements Serializable {
         fieldValue = getFieldValue(field, toMap);
       }
       assertFieldValue(field, fieldValue);
+      if (fieldValue == null){
+          continue;
+      }
 
       if (marshaller != null) {
         toRet.put(getFieldName(field), fieldValue);

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/BigQueryDataMarshallerByType.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/BigQueryDataMarshallerByType.java
@@ -51,6 +51,9 @@ final class BigQueryDataMarshallerByType implements Serializable {
    * @return a nested map of field name to field value.
    */
   Map<String, Object> mapFieldNameToValue(Object toMap) {
+    if (toMap == null) {
+      return null;
+    }
     Class<?> typeOfObjectToMap = toMap.getClass();
     Map<String, Object> toRet = new HashMap<>();
     Set<Field> fieldsToMap = getFieldsToSerialize(typeOfObjectToMap);

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/BigQuerySchemaMarshallerByType.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/BigQuerySchemaMarshallerByType.java
@@ -139,8 +139,8 @@ final class BigQuerySchemaMarshallerByType<T> implements Serializable {
       validateTypeForSchemaMarshalling(type);
       Set<Field> fieldsToMap = getFieldsToSerialize(type);
       for (Field field : fieldsToMap) {
-        if ((marshallers != null && !marshallers.containsKey(field))
-            || BigqueryFieldMarshallers.getMarshaller(field.getType()) == null) {
+        if ((marshallers == null || !marshallers.containsKey(field))
+            && BigqueryFieldMarshallers.getMarshaller(field.getType()) == null) {
           validateType(field.getType(), marshallers);
         }
       }

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/BigQueryDataMarshallerTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/BigQueryDataMarshallerTest.java
@@ -373,26 +373,43 @@ public class BigQueryDataMarshallerTest extends TestCase {
             }
           }
         });
+    marshallers.put(ClassWithUnsupportedType.class.getDeclaredField("blob"),
+        new BigqueryFieldMarshaller() {
+
+          @Override
+          public Class<?> getSchemaType() {
+            return String.class;
+          }
+
+          @Override
+          public Object getFieldValue(Field field, Object object) {
+            return "override";
+          }
+        });    
     BigQueryDataMarshallerTester<ClassWithUnsupportedType> tester =
         new BigQueryDataMarshallerTester<>(
             new BigQueryMarshallerByType<>(ClassWithUnsupportedType.class, marshallers));
-    tester.testGeneratedJson("{\"ip\":\"00000001-0002-0003-0004-000000000005\",\"id\":5}",
-        new ClassWithUnsupportedType(UUID.fromString("1-2-3-4-5"), 5));
+    tester.testGeneratedJson("{\"ip\":\"00000001-0002-0003-0004-000000000005\",\"id\":5,\"blob\":\"override\"}",
+        new ClassWithUnsupportedType(UUID.fromString("1-2-3-4-5"), 5, "blob"));
 
     tester.testSchema(new TableSchema().setFields(Lists.newArrayList(
         new TableFieldSchema().setName("ip").setType("string"), new TableFieldSchema().setName("id")
-            .setType("integer").setMode(BigQueryFieldMode.REQUIRED.getValue()))));
+        .setType("integer").setMode(BigQueryFieldMode.REQUIRED.getValue()),
+        new TableFieldSchema().setName("blob").setType("string"))));
   }
 
   private static class ClassWithUnsupportedType {
+    @SuppressWarnings("unused")
+    Object blob;
     @SuppressWarnings("unused")
     UUID ip;
     @SuppressWarnings("unused")
     int id;
 
-    public ClassWithUnsupportedType(UUID ip, int id) {
+    public ClassWithUnsupportedType(UUID ip, int id, Object blob) {
       this.ip = ip;
       this.id = id;
+      this.blob = blob;
     }
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/BigQueryDataMarshallerTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/BigQueryDataMarshallerTest.java
@@ -73,7 +73,7 @@ public class BigQueryDataMarshallerTest extends TestCase {
       try {
         assertTrue(mapper.readTree(expected).equals(mapper.readTree(actualJson)));
       } catch (IOException e) {
-        fail("Exception while serializing. Expected " + expected);
+        fail("Exception while serializing. Expected " + expected + " got " + actualJson);
       }
     }
 
@@ -335,6 +335,44 @@ public class BigQueryDataMarshallerTest extends TestCase {
     public ClassWithMap(Map map, int id) {
       this.map = map;
       this.id = id;
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public void testGeneratedJsonForClassWithRecord() {
+    BigQueryDataMarshallerTester<ClassWithRecord> tester =
+      new BigQueryDataMarshallerTester<ClassWithRecord>(
+        new BigQueryMarshallerByType<ClassWithRecord>(ClassWithRecord.class));
+
+    tester.testGeneratedJson("{\"record\":null}",
+      new ClassWithRecord(null));
+
+    tester.testGeneratedJson("{\"record\":{\"name\":\"myname\",\"value\":\"myvalue\"}}",
+      new ClassWithRecord(new ClassWithRecord.Record("myname","myvalue")));
+
+    tester.testSchema(new TableSchema().setFields(Lists.newArrayList(new TableFieldSchema()
+      .setName("record").setType("record").setFields(Lists.newArrayList(new TableFieldSchema()
+        .setName("name").setType("string"), new TableFieldSchema()
+        .setName("value").setType("string"))))));
+  }
+
+
+  private static class ClassWithRecord {
+    private static class Record{
+      public String name;
+      public String value;
+      public Record(String name, String value){
+          this.name=name;
+          this.value=value;
+      }
+    }
+      
+    @SuppressWarnings("unused")
+    Record record;
+
+    @SuppressWarnings("unused")
+    public ClassWithRecord(Record record) {
+      this.record = record;
     }
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/BigQueryDataMarshallerTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/BigQueryDataMarshallerTest.java
@@ -344,18 +344,27 @@ public class BigQueryDataMarshallerTest extends TestCase {
       new BigQueryDataMarshallerTester<ClassWithRecord>(
         new BigQueryMarshallerByType<ClassWithRecord>(ClassWithRecord.class));
 
-    tester.testGeneratedJson("{\"record\":null}",
-      new ClassWithRecord(null));
+    tester.testGeneratedJson("{}",
+     new ClassWithRecord(null,null));
 
     tester.testGeneratedJson("{\"record\":{\"name\":\"myname\",\"value\":\"myvalue\"}}",
-      new ClassWithRecord(new ClassWithRecord.Record("myname","myvalue")));
+     new ClassWithRecord(new ClassWithRecord.Record("myname","myvalue"), null));
+
+    tester.testGeneratedJson(
+     "{\"record\":{\"name\":\"name\",\"value\":\"value\"},\"records\":[{\"name\":\"name\",\"value\":\"value\"}]}",
+     new ClassWithRecord(new ClassWithRecord.Record("name","value"),
+      Lists.newArrayList(new ClassWithRecord.Record("name","value"))));
+
 
     tester.testSchema(new TableSchema().setFields(Lists.newArrayList(new TableFieldSchema()
-      .setName("record").setType("record").setFields(Lists.newArrayList(new TableFieldSchema()
-        .setName("name").setType("string"), new TableFieldSchema()
-        .setName("value").setType("string"))))));
+        .setName("records").setType("record").setMode("REPEATED").setFields(Lists.newArrayList(new TableFieldSchema()
+          .setName("name").setType("string"), new TableFieldSchema()
+          .setName("value").setType("string"))),
+      new TableFieldSchema()
+        .setName("record").setType("record").setFields(Lists.newArrayList(new TableFieldSchema()
+          .setName("name").setType("string"), new TableFieldSchema()
+          .setName("value").setType("string"))))));
   }
-
 
   private static class ClassWithRecord {
     private static class Record{
@@ -369,10 +378,12 @@ public class BigQueryDataMarshallerTest extends TestCase {
       
     @SuppressWarnings("unused")
     Record record;
+    List<Record> records;
 
     @SuppressWarnings("unused")
-    public ClassWithRecord(Record record) {
+    public ClassWithRecord(Record record, List<Record> records) {
       this.record = record;
+      this.records = records;
     }
   }
 


### PR DESCRIPTION
Don't fail when speciyfing BigQueryFieldMarshaller for unsupported types.

Prior to this fix it wasn't possible to define a custom BigqueryFieldMarshaller for an 'Object'
field. Doing so would generate the error,

'java.lang.IllegalArgumentException: Type cannot be marshalled into bigquery schema. Object'

The cause was invalid logic when checking for an override before validing the type for marshalling.
We want to call validateType on the field only when we don't have a custom marshaller defined

and there is no out of the box marshaller

  (BigqueryFieldMarshallers.getMarshaller(field.getType()) == null).

Previously the logic was to call validateType whenever there was no out of the box marshaller
regardless of a custom marshaller being defined or not.