### PR TITLE
Add base_path to run kwargs

### DIFF
--- a/python/src/mapreduce/mapper_pipeline.py
+++ b/python/src/mapreduce/mapper_pipeline.py
@@ -67,7 +67,8 @@ class MapperPipeline(pipeline_base._OutputSlotsMixin,
           input_reader_spec,
           output_writer_spec=None,
           params=None,
-          shards=None):
+          shards=None,
+          base_path=None):
     """Start a mapreduce job.
 
     Args:
@@ -82,7 +83,8 @@ class MapperPipeline(pipeline_base._OutputSlotsMixin,
     """
     if shards is None:
       shards = parameters.config.SHARD_COUNT
-
+    if base_path is None:
+      base_path = parameters.config.BASE_PATH
     mapreduce_id = control.start_map(
         job_name,
         handler_spec,
@@ -92,6 +94,7 @@ class MapperPipeline(pipeline_base._OutputSlotsMixin,
             "done_callback": self.get_callback_url(),
             "done_callback_method": "GET",
             "pipeline_id": self.pipeline_id,
+            "base_path": base_path,
         },
         shard_count=shards,
         output_writer_spec=output_writer_spec,
@@ -99,7 +102,7 @@ class MapperPipeline(pipeline_base._OutputSlotsMixin,
         )
     self.fill(self.outputs.job_id, mapreduce_id)
     self.set_status(console_url="%s/detail?mapreduce_id=%s" % (
-        (parameters.config.BASE_PATH, mapreduce_id)))
+        (base_path, mapreduce_id)))
 
   def try_cancel(self):
     """Always allow mappers to be canceled and retried."""


### PR DESCRIPTION
Currently it's annoying having to use appengine_config.py to set a different base path, it's also not dynamic. This PR makes the MapperPipeline class more usable