### PR TITLE
Update pipeline module import to no longer fail on ImportError, but if the module doesn't exist

### DIFF
--- a/python/src/mapreduce/base_handler.py
+++ b/python/src/mapreduce/base_handler.py
@@ -23,16 +23,19 @@
 
 import httplib
 import logging
+import pkgutil
+import importlib
 
 try:
   import json
 except ImportError:
   import simplejson as json
 
-try:
-  from mapreduce import pipeline_base
-except ImportError:
-  pipeline_base = None
+pipeline_base = None
+
+if pkgutil.find_loader('mapreduce.pipeline_base') is not None:
+  pipeline_base = importlib.import_module('mapreduce.pipeline_base')
+
 try:
   # Check if the full cloudstorage package exists. The stub part is in runtime.
   import cloudstorage

--- a/python/src/mapreduce/base_handler.py
+++ b/python/src/mapreduce/base_handler.py
@@ -22,9 +22,9 @@
 # pylint: disable=g-import-not-at-top
 
 import httplib
+import importlib
 import logging
 import pkgutil
-import importlib
 
 try:
   import json


### PR DESCRIPTION
Using the try/catch method on the pipeline_base module obfuscates problems within the imported module. 

For example, if the pipeline dependency wouldn't properly be installed, there would be no way of knowing it, as the assumption would be (after reading the code) that the pipeline_base module itself failed to load/was not available/etc. This could happen in a malfunctioning CI script and it would introduce a bug that is hard to find and fix.