### PR TITLE
Support equality filter in db.ListProperty

### DIFF
--- a/python/src/mapreduce/input_readers.py
+++ b/python/src/mapreduce/input_readers.py
@@ -670,6 +670,11 @@ class DatastoreInputReader(AbstractDatastoreInputReader):
             "Property %s is not defined for entity type %s",
             prop, model_class.kind())
 
+      if isinstance(properties[prop], db.ListProperty):
+        # for db.ListProperty validate expect a list, but filter expect
+        # a single value
+        val = [val]
+
       # Validate the value of each filter. We need to know filters have
       # valid value to carry out splits.
       try:

--- a/python/test/mapreduce/input_readers_test.py
+++ b/python/test/mapreduce/input_readers_test.py
@@ -810,6 +810,12 @@ class DatastoreInputReaderTest(DatastoreInputReaderTestCommon):
                       self.reader_cls.validate,
                       mapper_spec)
 
+    params["filters"] = [('mvp_str', '=', '1')]
+    self.reader_cls.validate(mapper_spec)
+
+    params["filters"] = [('mvp_int', '=', 1)]
+    self.reader_cls.validate(mapper_spec)
+
   def _set_vals(self, entities, a_vals, b_vals):
     """Set a, b values for entities."""
     vals = []

--- a/python/test/testlib/testutil.py
+++ b/python/test/testlib/testutil.py
@@ -92,6 +92,8 @@ class TestEntity(db.Model):
 
   a = db.IntegerProperty()
   b = db.IntegerProperty()
+  mvp_str = db.StringListProperty()
+  mvp_int = db.ListProperty(int, required=True, indexed=True)
 
 
 class NdbTestEntity(ndb.Model):
@@ -99,6 +101,9 @@ class NdbTestEntity(ndb.Model):
 
   a = ndb.IntegerProperty()
   b = ndb.IntegerProperty()
+
+  mvp_str = ndb.StringProperty(repeated=True)
+  mvp_int = ndb.IntegerProperty(repeated=True)
 
 
 class TestEntityWithDot(db.Model):


### PR DESCRIPTION
db.ListProperty.validate expects the param to be a value to be assigned to the field (which is a List). However the .filter() method expects the value to be a single element. This issue only occurs for db.ListProperty, ndbProperty with repeated flag works just fine.

Without this changes:
```
python test/mapreduce/input_readers_test.py 
======================================================================
ERROR: testValidate_Filters (__main__.DatastoreInputReaderTest)
Tests validating filters parameter.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/mapreduce/input_readers_test.py", line 814, in testValidate_Filters
    self.reader_cls.validate(mapper_spec)
  File "/Users/eko/projects/appengine-mapreduce/python/src/mapreduce/input_readers.py", line 640, in validate
    cls._validate_filters(filters, model_class)
  File "/Users/eko/projects/appengine-mapreduce/python/src/mapreduce/input_readers.py", line 683, in _validate_filters
    raise errors.BadReaderParamsError(e)
BadReaderParamsError: Property mvp_str must be a list
```



With this changes
```
......................................................................................................WARNING:root:File /testing/file-000 may have been removed. Skipping file.
WARNING:root:File /testing/file-018 may have been removed. Skipping file.
....................................................................
----------------------------------------------------------------------
Ran 170 tests in 26.231s

OK

```
