### PR TITLE
allow lock timeout for a slice of a sharded task to be configured via `MapSettings`

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapSettings.java
@@ -133,8 +133,8 @@ public class MapSettings implements Serializable {
     }
 
     /**
-     * Sets ratio for much longer than millisPerSlice before slice will be considered
-     * to have timed out.
+     * Sets a ratio for how much time beyond millisPerSlice must elapse before slice will be
+     * considered to have failed due to a timeout.
      */
     public B setSliceTimeoutRatio(double sliceTimeoutRatio) {
       Preconditions.checkArgument(sliceTimeoutRatio >= 1.0);

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapSettings.java
@@ -48,6 +48,7 @@ public class MapSettings implements Serializable {
   public static final String CONTROLLER_PATH = "controllerCallback";
   public static final String WORKER_PATH = "workerCallback";
   public static final int DEFAULT_MILLIS_PER_SLICE = 180_000;
+  public static final double DEFAULT_SLICE_TIMEOUT_RATIO = 1.1;
   public static final int DEFAULT_SHARD_RETRIES = 4;
   public static final int DEFAULT_SLICE_RETRIES = 20;
 
@@ -56,6 +57,7 @@ public class MapSettings implements Serializable {
   private final String module;
   private final String workerQueueName;
   private final int millisPerSlice;
+  private final double sliceTimeoutRatio;
   private final int maxShardRetries;
   private final int maxSliceRetries;
 
@@ -66,6 +68,7 @@ public class MapSettings implements Serializable {
     protected String backend;
     protected String workerQueueName;
     protected int millisPerSlice = DEFAULT_MILLIS_PER_SLICE;
+    protected double sliceTimeoutRatio = DEFAULT_SLICE_TIMEOUT_RATIO;
     protected int maxShardRetries = DEFAULT_SHARD_RETRIES;
     protected int maxSliceRetries = DEFAULT_SLICE_RETRIES;
 
@@ -130,6 +133,16 @@ public class MapSettings implements Serializable {
     }
 
     /**
+     * Sets ratio for much longer than millisPerSlice before slice will be considered
+     * to have timed out.
+     */
+    public B setSliceTimeoutRatio(double sliceTimeoutRatio) {
+      Preconditions.checkArgument(sliceTimeoutRatio >= 1.0);
+      this.sliceTimeoutRatio = sliceTimeoutRatio;
+      return self();
+    }
+
+    /**
      * The number of times a Shard can fail before it gives up and fails the whole job.
      */
     public B setMaxShardRetries(int maxShardRetries) {
@@ -176,6 +189,7 @@ public class MapSettings implements Serializable {
     backend = builder.backend;
     workerQueueName = checkQueueSettings(builder.workerQueueName);
     millisPerSlice = builder.millisPerSlice;
+    sliceTimeoutRatio = builder.sliceTimeoutRatio;
     maxShardRetries = builder.maxShardRetries;
     maxSliceRetries = builder.maxSliceRetries;
   }
@@ -200,6 +214,10 @@ public class MapSettings implements Serializable {
     return millisPerSlice;
   }
 
+  double getSliceTimeoutRatio() {
+    return sliceTimeoutRatio;
+  }
+
   int getMaxShardRetries() {
     return maxShardRetries;
   }
@@ -216,6 +234,7 @@ public class MapSettings implements Serializable {
         + module + ", "
         + workerQueueName + ", "
         + millisPerSlice + ", "
+        + sliceTimeoutRatio + ", "
         + maxSliceRetries + ", "
         + maxShardRetries + ")";
   }
@@ -284,7 +303,7 @@ public class MapSettings implements Serializable {
         .setMaxShardRetries(maxShardRetries)
         .setMaxSliceRetries(maxSliceRetries)
         .setSliceTimeoutMillis(
-            Math.max(DEFAULT_SLICE_TIMEOUT_MILLIS, (int) (millisPerSlice * 1.1)));
+            Math.max(DEFAULT_SLICE_TIMEOUT_MILLIS, (int) (millisPerSlice * sliceTimeoutRatio)));
     return runWithRetries(new Callable<ShardedJobSettings>() {
       @Override public ShardedJobSettings call() {
         return builder.build();

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobSettings.java
@@ -45,11 +45,11 @@ public final class ShardedJobSettings implements Serializable {
     private String version;
     private String pipelineStatusUrl;
     private String mrStatusUrl;
-    private String controllerPath = "/mapreduce/controllerCallback";
-    private String workerPath = "/mapreduce/workerCallback";
+    private String controllerPath = DEFAULT_BASE_URL + CONTROLLER_PATH;
+    private String workerPath = DEFAULT_BASE_URL + WORKER_PATH;
     private String queueName = "default";
-    private int maxShardRetries = 4;
-    private int maxSliceRetries = 20;
+    private int maxShardRetries = DEFAULT_SHARD_RETRIES;
+    private int maxSliceRetries = DEFAULT_SLICE_RETRIES;
     private int sliceTimeoutMillis = DEFAULT_SLICE_TIMEOUT_MILLIS;
 
     public Builder setPipelineStatusUrl(String pipelineStatusUrl) {

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobSettings.java
@@ -12,7 +12,6 @@ import static com.google.appengine.tools.mapreduce.MapSettings.WORKER_PATH;
 import static com.google.appengine.tools.mapreduce.MapSettings.CONTROLLER_PATH;
 import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_SHARD_RETRIES;
 import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_SLICE_RETRIES;
-import static com.google.appengine.tools.mapreduce.impl.shardedjob.ShardedJobSettings.DEFAULT_SLICE_TIMEOUT_MILLIS;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobSettings.java
@@ -7,6 +7,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.appengine.api.backends.BackendServiceFactory;
 import com.google.appengine.api.modules.ModulesServiceFactory;
 
+import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_BASE_URL;
+import static com.google.appengine.tools.mapreduce.MapSettings.WORKER_PATH;
+import static com.google.appengine.tools.mapreduce.MapSettings.CONTROLLER_PATH;
+import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_SHARD_RETRIES;
+import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_SLICE_RETRIES;
+import static com.google.appengine.tools.mapreduce.impl.shardedjob.ShardedJobSettings.DEFAULT_SLICE_TIMEOUT_MILLIS;
+
 import java.io.IOException;
 import java.io.Serializable;
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/MapSettingsTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/MapSettingsTest.java
@@ -5,6 +5,7 @@ package com.google.appengine.tools.mapreduce;
 import static com.google.appengine.tools.mapreduce.MapSettings.CONTROLLER_PATH;
 import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_BASE_URL;
 import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_MILLIS_PER_SLICE;
+import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_SLICE_TIMEOUT_RATIO;
 import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_SHARD_RETRIES;
 import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_SLICE_RETRIES;
 import static com.google.appengine.tools.mapreduce.MapSettings.WORKER_PATH;
@@ -72,6 +73,7 @@ public class MapSettingsTest extends TestCase {
     assertEquals(DEFAULT_MILLIS_PER_SLICE, mrSettings.getMillisPerSlice());
     assertEquals(DEFAULT_SHARD_RETRIES, mrSettings.getMaxShardRetries());
     assertEquals(DEFAULT_SLICE_RETRIES, mrSettings.getMaxSliceRetries());
+    assertEquals(DEFAULT_SLICE_TIMEOUT_RATIO, mrSettings.getSliceTimeoutRatio());
   }
 
   public void testNonDefaultSettings() {
@@ -91,6 +93,12 @@ public class MapSettingsTest extends TestCase {
       builder.setMillisPerSlice(-1);
     } catch (IllegalArgumentException ex) {
       // expected
+    }
+    builder.setSliceTimeoutRatio(1.5);
+    try {
+      builder.setSliceTimeoutRatio(0.8);
+    } catch (IllegalArgumentException ex) {
+      //expected
     }
     builder.setMaxShardRetries(1);
     try {


### PR DESCRIPTION
Basic problem is that you can configure `millisPerSlice` via [`MapSettings`](https://github.com/GoogleCloudPlatform/appengine-mapreduce/blob/master/java/src/main/java/com/google/appengine/tools/mapreduce/MapSettings.java#L126).  When a `MapJob` runs, it continues to execute the slice until it's been executing for >= that many milliseconds (see example implementation in [MapShardTask](https://github.com/GoogleCloudPlatform/appengine-mapreduce/blob/master/java/src/main/java/com/google/appengine/tools/mapreduce/impl/MapShardTask.java#L60-L62)).

While this shard task is executing, the share is "locked".  This lock is considered to be held for a timeout that is `millisPerSlice * 1.1` ([MapSettings:286](https://github.com/GoogleCloudPlatform/appengine-mapreduce/blob/master/java/src/main/java/com/google/appengine/tools/mapreduce/MapSettings.java#L287)). If that lock has not been released and that much time has passed, ShardJobRunner will deem the slice as failed (see [`ShardJobRunner.handleLockHeld()`](https://github.com/GoogleCloudPlatform/appengine-mapreduce/blob/6e103ac52855c3214de3ec3721d6ec0e7edd5f77/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java#L301-L325)). 

This PR makes that `1.1` value configurable via `MapSettings` (or `MapReduceSettings`).  I've called this `sliceTimeoutRatio`, but certainly open to suggestions. This PR also replaces a few other magic numbers with the appropriate constants. 
