### PR TITLE
Log the exception why we're aborting the whole mapreduce

### DIFF
--- a/python/src/mapreduce/base_handler.py
+++ b/python/src/mapreduce/base_handler.py
@@ -128,7 +128,7 @@ class TaskQueueHandler(webapp.RequestHandler):
     # pylint: disable=bare-except
     except:
       self._preprocess_success = False
-      logging.error(
+      logging.exception(
           "Preprocess task %s failed. Dropping it permanently.",
           self.request.headers["X-AppEngine-TaskName"])
       self._drop_gracefully()


### PR DESCRIPTION
My multiple-day-long mapreduce just died. Without any retries. Without any log statements explaining why. Sigh.

I'm not going to push for a retry (since arguably the preprocess would just repeatedly fail, and one can agree/disagree as to whether it should retry with the intent that the programmer fixes something on a subsequent retry).

But it should at the very least log the exception, so the programmer can attempt to fix it, before he or she attempts to run the multiple-day-long mapreduce again.