### PR TITLE
Use a deterministic hash function

### DIFF
--- a/python/src/mapreduce/shuffler.py
+++ b/python/src/mapreduce/shuffler.py
@@ -32,6 +32,7 @@ import heapq
 import logging
 import pickle
 import time
+import zlib
 
 import pipeline
 from pipeline import common as pipeline_common
@@ -525,7 +526,7 @@ class _HashingGCSOutputWriter(output_writers.OutputWriter):
       logging.error("Expecting a tuple, but got %s: %s",
                     data.__class__.__name__, data)
 
-    file_index = key.__hash__() % len(self._filehandles)
+    file_index = zlib.adler32(key) % len(self._filehandles)
 
     # Work-around: Since we don't have access to the context in the to_json()
     # function, but we need to flush each pool before we serialize the


### PR DESCRIPTION
Python's built-in hash function changes its output based on the seed. In GAE, it appears that the same seed is always used. However, this is not guaranteed to always be the case.

The App Engine SDK starts runtime instances with a random seed. When the dev_appserver has scaled to use multiple instances, I've run into cases where the same key will end up in multiple shard outputs.

I chose adler32 over the functions in hashlib due to its speed and simplicity.